### PR TITLE
Update GitHub Actions versions to fix deployment issues

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
       - name: GitHub Action for npx
         uses: mikeal/npx@1.0.0
       - name: Run NPM Install
@@ -40,10 +40,10 @@ jobs:
       - name: Run the static build step
         run: npx @devdojo/static build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: './_site/'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Hi! First of all, thanks for static – it's an awesome project, and I really appreciate the work you've put into it!

I recently used it and ran into some issues with the GitHub Actions workflow. After some debugging, I found that the problems were related to outdated action versions. Updating them resolved the issues on my end.

Here are the changes I made:

actions/checkout@v3 → actions/checkout@v4
actions/configure-pages@v3 → actions/configure-pages@v4
actions/upload-pages-artifact@v2 → actions/upload-pages-artifact@v3
actions/deploy-pages@v2 → actions/deploy-pages@v3

I think this might be the case for other templates.

Best regards,
Adriano Dias



